### PR TITLE
[TASK] Add togglable edit/preview button

### DIFF
--- a/_config/buttons.yml
+++ b/_config/buttons.yml
@@ -42,3 +42,7 @@ MarkdownTextareaField:
       affix: '&#x0D;&#x0A;- - -&#x0D;&#x0A;'
       pic: 'text_horizontalrule.png'
       name: 'Horizontal line'
+    togglepreview:
+      label: 'Edit/Preview'
+      name: 'Edit/Preview'
+      preview: true

--- a/templates/css/styles.css
+++ b/templates/css/styles.css
@@ -1,5 +1,6 @@
 .field.markdowntextarea .toolbar {
 	margin-bottom: 5px;
+	height: 32px;
 }
 
 .field.markdowntextarea .toolbar button:first-child {
@@ -16,8 +17,13 @@
 	background: white;
 	border: 1px solid #B3B3B3;
 	border-radius: 4px;
-	-webkit-transition: height 1s ;
-	-moz-transition: height 1s ;
-	-o-transition: height 1s ;
-	transition: height 1s ;
+	-webkit-transition: height 1s;
+	-moz-transition: height 1s;
+	-o-transition: height 1s;
+	transition: height 1s;
+	display: none;
+}
+
+.field.markdowntextarea .toolbar button[data-preview="true"] {
+	float: right;
 }

--- a/templates/forms/MarkdownTextareaField.ss
+++ b/templates/forms/MarkdownTextareaField.ss
@@ -1,6 +1,7 @@
 <div class="toolbar">
 	<% loop $ToolbarButtons %>
-		<button data-prefix="$prefix" data-affix="$affix" title="$name">
+		<button data-prefix="$prefix" data-affix="$affix" title="$name"
+            <% if $preview %> data-preview="true" <% end_if %>>
 			<% if $pic %>
 				<img src="markdowntextareafield/templates/images/buttons/$pic" alt="$name" title="$name">
 			<% else %>

--- a/templates/javascript/script.js
+++ b/templates/javascript/script.js
@@ -32,6 +32,13 @@
 				if (this.attr('data-prefix') || this.attr('data-affix')) {
 					this.getTextarea().surroundSelectedText(this.attr('data-prefix'), this.attr('data-affix'));
 				}
+
+				// Toggle edit/preview mode
+				if (this.attr('data-preview')) {
+					this.getTextarea().toggle();
+					this.getPreview().toggle();
+					$('.field.markdowntextarea button').not(this).toggle();
+				}
 			},
 
 		});


### PR DESCRIPTION
Suggested modification: add a togglable edit/preview button (like GitHub) to minimize the space used on the page.
- Hide and show the preview/editor areas
- Hide the buttons while in preview mode
- Float the button to the right
