### PR TITLE
Hotfix for the markdown editor

### DIFF
--- a/forms/MarkdownTextareaField.php
+++ b/forms/MarkdownTextareaField.php
@@ -66,7 +66,10 @@ class MarkdownTextareaField extends TextareaField
                 registerMarkdownEditor();
 
                 jQuery(document).ajaxComplete(function() {
-                   registerMarkdownEditor();
+                   //This only register the editor when you save the element
+                    if (!response.url.startsWith('/admin/markdown/internallinks')) {
+                        registerMarkdownEditor();
+                    }
                 });
 JS
         );


### PR DESCRIPTION
It fixes the double registration when the callback doesn't refresh all the right side panel. This case only applies for the autocomplete feature for urls
